### PR TITLE
[Step.2] Swagger(SpringFox)の導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ Swaggerを適用させる前に、サンプル用の簡単なAPIを作成しま�
 - /api/sample/{id} PUT 登録・更新API
 - /api/sample/{id} DELETE 削除API
 
+### Step.2 Swagger Configの作成
+
+SpringでSwaggerを使用するために、 `SpringFox`を使用します。
+
+SpringFoxはSpringプロジェクトの内の１つで、API仕様書を自動で生成してくれるライブラリです。
+SpringFoxは実行時に、自動でアプリケーションをスキャンしてAPIの仕様を推論します。
+
+導入した `SpringFox` ライブラリとバージョンは下記の通り。（2018/10/11現在の最新バージョン）
+
+- io.springfox:springfox-swagger2:2.9.2
+- io.springfox:springfox-swagger-ui:2.9.2
+
+次にSwaggerを有効にするためのJavaConfigを作成します。
+このStepで設定する内容は最小限のものに留めています。
+
+SwaggerのJavaConfigを作成するだけで Swagger が有効になりました。
+下記のリンクで、Swaggerで作成されたAPI仕様書が確認できます。
+http://localhost:8080/swagger-ui.html
+
 
 ## 環境情報
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,6 @@ repositories {
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-web')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
-    compile group: 'com.google.guava', name: 'guava', version: '18.0'
+    compile('io.springfox:springfox-swagger2:2.9.2')
+    compile('io.springfox:springfox-swagger-ui:2.9.2')
 }

--- a/src/main/java/com/github/tkrplus/swaggerspringboot/web/configuration/SwaggerConfig.java
+++ b/src/main/java/com/github/tkrplus/swaggerspringboot/web/configuration/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.github.tkrplus.swaggerspringboot.web.configuration;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+  @Bean
+  public Docket swaggerPlugin() {
+    return new Docket(DocumentationType.SWAGGER_2)
+        .select()
+        .build();
+  }
+}


### PR DESCRIPTION
### Step.2 Swagger Configの作成

SpringでSwaggerを使用するために、 `SpringFox`を使用します。

SpringFoxはSpringプロジェクトの内の１つで、API仕様書を自動で生成してくれるライブラリです。
SpringFoxは実行時に、自動でアプリケーションをスキャンしてAPIの仕様を推論します。

導入した `SpringFox` ライブラリとバージョンは下記の通り。（2018/10/11現在の最新バージョン）

- io.springfox:springfox-swagger2:2.9.2
- io.springfox:springfox-swagger-ui:2.9.2

次にSwaggerを有効にするためのJavaConfigを作成します。
このStepで設定する内容は最小限のものに留めています。

SwaggerのJavaConfigを作成するだけで Swagger が有効になりました。
下記のリンクで、Swaggerで作成されたAPI仕様書が確認できます。
http://localhost:8080/swagger-ui.html
