### PR TITLE
[Step.3] API仕様書としての基本情報を設定する

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ SwaggerのJavaConfigを作成するだけで Swagger が有効になりました
 下記のリンクで、Swaggerで作成されたAPI仕様書が確認できます。
 http://localhost:8080/swagger-ui.html
 
+### Step.3 API仕様書としての基本情報を設定する
+
+API仕様書として必要な基本情報を設定します。
+
+Step.2で作成した`SwaggerConfig.java`で基本情報を追加します。追加する情報は下記です。
+
+- groupName: APIごとにグルーピングする場合は名前をつけます。（例：internal, public）
+- title: API仕様書のタイトル
+- description: APIに関する説明書
+- version: APIのバージョン
+
+API仕様書のタイトルや説明書は、編集しやすさを考えて`application.yaml`で指定された値を参照する形にしました。
+
+次に、API仕様書に載せるAPIのpathを指定します。
+Step.2までのAPI仕様書ではSpringBootがデフォルトで用意されているAPIも反映されてしまっていました。
+今回は`/api`配下のAPIを対象とします。
+
 
 ## 環境情報
 

--- a/src/main/java/com/github/tkrplus/swaggerspringboot/web/configuration/SwaggerConfig.java
+++ b/src/main/java/com/github/tkrplus/swaggerspringboot/web/configuration/SwaggerConfig.java
@@ -1,8 +1,13 @@
 package com.github.tkrplus.swaggerspringboot.web.configuration;
 
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -11,10 +16,34 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 public class SwaggerConfig {
 
+  @Value("${app.api.version}")
+  private String version;
+
+  @Value("${swagger.api.info.title}")
+  private String title;
+
+  @Value("${swagger.api.info.description}")
+  private String description;
+
   @Bean
   public Docket swaggerPlugin() {
     return new Docket(DocumentationType.SWAGGER_2)
+        .groupName("public api")
+        .apiInfo(apiInfo())
         .select()
+        .paths(paths())
         .build();
+  }
+
+  private ApiInfo apiInfo() {
+    return new ApiInfoBuilder()
+        .title(title)
+        .description(description)
+        .version(version)
+        .build();
+  }
+
+  private Predicate<String> paths() {
+    return Predicates.or(Predicates.containsPattern("/api"));
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,12 @@
+app:
+  api:
+    version: 2
+
+swagger:
+  api:
+    info:
+      title: Swagger x SpringBoot Sample API
+      description:
+        Spring Boot 2.x系での Swagger のサンプルです。
+        詳細は下記リンクを参照してください。
+        https://github.com/tkrplus/swagger-spring-boot


### PR DESCRIPTION
### Step.3 API仕様書としての基本情報を設定する

API仕様書として必要な基本情報を設定します。

Step.2で作成した`SwaggerConfig.java`で基本情報を追加します。追加する情報は下記です。

- groupName: APIごとにグルーピングする場合は名前をつけます。（例：internal, public）
- title: API仕様書のタイトル
- description: APIに関する説明書
- version: APIのバージョン

API仕様書のタイトルや説明書は、編集しやすさを考えて`application.yaml`で指定された値を参照する形にしました。

次に、API仕様書に載せるAPIのpathを指定します。
Step.2までのAPI仕様書ではSpringBootがデフォルトで用意されているAPIも反映されてしまっていました。
今回は`/api`配下のAPIを対象とします。